### PR TITLE
support multiple base directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ wget https://raw.githubusercontent.com/kfkonrad/workspace-change-directory/main/
 
 ## Usage
 
-You can set the base directory for the search by setting `WCD_BASE_DIR`. If unset it defaults to `~/workspace`.
+You can set the base directory for the search by setting `WCD_BASE_DIR`. If unset it defaults to `~/workspace`. Multiple base directories are supported via the `:` separator, so for example `WCD_BASE_DIR='$HOME/workspace:/mnt/projects'` will result in `wcd` searching for repos in `~/workspace` and `/mnt/projects`.
 
 ```sh
 wcd <repo-name>

--- a/bash/wcd.sh
+++ b/bash/wcd.sh
@@ -26,7 +26,8 @@ __wcd_find_repos() {
     local base_dir=$(test -z "$WCD_BASE_DIR" && echo ~/workspace || echo $WCD_BASE_DIR)
 
     # Initialize a queue with the base directory
-    local queue=("$base_dir")
+    local queue=()
+    IFS=':' read -r -a queue <<< "$base_dir"
     local repos=()
 
     # Breadth-first search, skipping subdirectories of git repos
@@ -83,7 +84,8 @@ __wcd_select_and_cd_repo() {
 
 __wcd_find_any_repos() {
     local base_dir=$(test -z "$WCD_BASE_DIR" && echo ~/workspace || echo $WCD_BASE_DIR)
-    local queue=("$base_dir")
+    local queue=()
+    IFS=':' read -r -a queue <<< "$base_dir"
     local repos=()
 
     # Breadth first search, skipping subdirectories of git repos

--- a/completions/wcd.fish
+++ b/completions/wcd.fish
@@ -1,7 +1,7 @@
 function __wcd_find_any_repos
     set base_dir (test -z "$WCD_BASE_DIR" && echo ~/workspace || echo $WCD_BASE_DIR)
 
-    set -l queue $base_dir
+    set -l queue (string split ':' "$base_dir")
     set -l repos
 
     # Breadth first search, skipping subdirectories of git repos

--- a/functions/wcd.fish
+++ b/functions/wcd.fish
@@ -25,7 +25,7 @@ function __wcd_find_repos
     set base_dir (test -z "$WCD_BASE_DIR" && echo ~/workspace || echo $WCD_BASE_DIR)
 
 
-    set -l queue $base_dir
+    set -l queue (string split ':' "$base_dir")
     set -l repos
 
     # Breadth first search, skipping subdirectories of git repos

--- a/nushell/wcd.nu
+++ b/nushell/wcd.nu
@@ -27,7 +27,7 @@ def --env wcd [repo_name: string@repositories] {
 def __wcd_find_any_repos [] {
   let base_dir = $env.WCD_BASE_DIR? | default $"($nu.home-path)/workspace"
 
-  mut queue = [$base_dir]
+  mut queue = $base_dir | split row ':'
   mut repos = []
 
   # Breadth first search, skipping subdirectories of git repos
@@ -56,7 +56,7 @@ def __wcd_find_any_repos [] {
 def __wcd_find_repos [repo_name: string] {
     let base_dir = $env.WCD_BASE_DIR? | default $"($nu.home-path)/workspace"
 
-    mut queue = [$base_dir]
+    mut queue = $base_dir | split row ':'
     mut repos = []
 
     # Breadth first search, skipping subdirectories of git repos

--- a/zsh/wcd.sh
+++ b/zsh/wcd.sh
@@ -26,7 +26,8 @@ __wcd_find_repos() {
     local base_dir=$(test -z "$WCD_BASE_DIR" && echo ~/workspace || echo $WCD_BASE_DIR)
 
     # Initialize a queue with the base directory
-    local -a queue=("$base_dir")
+    local -a queue
+    IFS=':' read -r -A queue <<< "$base_dir"
     local -a repos
 
     # Breadth-first search, skipping subdirectories of git repos
@@ -88,7 +89,8 @@ __wcd_select_and_cd_repo() {
 
 __wcd_find_any_repos() {
     local base_dir=$(test -z "$WCD_BASE_DIR" && echo ~/workspace || echo $WCD_BASE_DIR)
-    local -a queue=("$base_dir")
+    local -a queue
+    IFS=':' read -r -A queue <<< "$base_dir"
     local -a repos
 
     # Breadth first search, skipping subdirectories of git repos


### PR DESCRIPTION
## Use Case
My local folder structure doesn't allow for a common workspace folder for all my repos, so it would be nice to (optionally) be able to specify multiple base directories which `wcd` will search for a matching repository.

## Implementation/Usage
Taking inspiration from how `$PATH` works, multiple base folders can now be specified by separating them via `:` in the
`WCD_BASE_DIR` environment variable.

## Edge Cases
Any existing configuration where `WCD_BASE_DIR` is set to a path which contains a `:` will break with this change. Given that we are talking about *base* directories and that POSIX explicitly forbids colons in the path-variable this project wouldn't be the first to rely on the fact that directory paths shouldn't contain colons.

## Testing
I made sure that the lines I changed produce the correct result in the different shells, i.e. if they result in an array/list being assigned to the `queue`-variable, but I only invoked the bash and zsh version fully (didn't want to do a full setup of `fish` and `nu` on my local system).